### PR TITLE
Add GitHub Pages deployment setup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@v4
+        id: deployment

--- a/README.md
+++ b/README.md
@@ -114,6 +114,17 @@ This application uses your browser's `localStorage` to save your item inventory 
 *   **State Management:** React Hooks (`useState`, `useCallback`, `useMemo`, `useEffect`)
 *   **Speech Recognition:** Web Speech API (browser dependent)
 
+## Deploying to GitHub Pages
+
+This repository includes a GitHub Actions workflow that builds the application
+using Vite and publishes the `dist` folder to GitHub Pages. To deploy:
+
+1. Push your changes to the `main` branch.
+2. In the repository settings, enable **GitHub Pages** and choose `GitHub
+   Actions` as the source.
+3. After the workflow completes, the app will be available at
+   `https://<your-user>.github.io/<your-repo>/`.
+
 ---
 
 *Pokémon and Pokémon character names are trademarks of Nintendo.*

--- a/index.html
+++ b/index.html
@@ -2,7 +2,8 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+  <!-- Use relative paths so the page works on GitHub Pages -->
+  <link rel="icon" type="image/svg+xml" href="./vite.svg" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Pokémon EV Calculator</title>
   <script src="https://cdn.tailwindcss.com"></script>
@@ -30,10 +31,10 @@
 }
 </script>
 <script src='https://cdn.jsdelivr.net/npm/tesseract.js@5/dist/tesseract.min.js' defer></script>
-<link rel="stylesheet" href="/index.css">
+<link rel="stylesheet" href="./index.css">
 </head>
 <body class="bg-slate-900 text-slate-100">
   <div id="root"></div>
-  <script type="module" src="/index.tsx"></script>
+  <script type="module" src="./index.tsx"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "predeploy": "npm run build",
+    "deploy": "gh-pages -d dist"
   },
   "dependencies": {
     "react": "^19.1.0",
@@ -15,6 +17,7 @@
   "devDependencies": {
     "@types/node": "^22.14.0",
     "typescript": "~5.7.2",
-    "vite": "^6.2.0"
+    "vite": "^6.2.0",
+    "gh-pages": "^6.0.0"
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,8 @@ import { defineConfig, loadEnv } from 'vite';
 export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
+      // Use relative paths so the app works when served from a subfolder
+      base: './',
       define: {
         'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
         'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)


### PR DESCRIPTION
## Summary
- use relative asset paths in `index.html`
- set `base: './'` in Vite config so the build works from a subfolder
- add `predeploy` and `deploy` scripts and `gh-pages` package
- document GitHub Pages deployment steps
- add GitHub Actions workflow to build and deploy to Pages

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f48312b08832a95b0c2252ecd0725